### PR TITLE
Adapt this Font Awesome snippet for the "New Naming Conventions in 4.0"

### DIFF
--- a/icon/bs3-icon.sublime-snippet
+++ b/icon/bs3-icon.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<i class="icon icon-${1:icon}"></i>
+<i class="fa-${1:name}-${2:shape}${3:-${4:o}${5:-${6:direction}}}"></i>
 ]]></content>
 	<tabTrigger>bs3-icon</tabTrigger>
 </snippet>


### PR DESCRIPTION
This replaces the `.icon` class for the new `.fa` class, makes the second argument (icon name) required and optionally allow to use the outline and direction arguments.

Following the official pattern: `fa-[name]-[shape]-[o]-[direction]`.
