### PR TITLE
Remove Substitution referencing to nonexistent $1 field

### DIFF
--- a/form/bs3-form-label.sublime-snippet
+++ b/form/bs3-form-label.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<label for="input${1/(\w+)/\u\1/g}" ${2:class="col-sm-2"}>${3}</label>
+<label for="${1:input-id}" ${2:class="col-sm-2"}>${3}</label>
 ]]></content>
 	<tabTrigger>bs3-form:label</tabTrigger>
 </snippet>


### PR DESCRIPTION
This substitution `input${1/(\w+)/\u\1/g}` was throwing an error and consequentially shutdown Sublime as referenced in Issue #24 (I'm using SBT2x32, Win7, x64) because there is no $1 field to substitute. It would work if for example we put: `<label ${1} for="input${1/(\w+)/\u\1/g}" ${2:class="col-sm-2"}>${3}</label>`.  The same goes to form/bs3-input-label.sublime-snippet
