### PR TITLE
Remove Substitution referencing to nonexistent $1 field and tabTrigger t...

### DIFF
--- a/form/bs3-input-label.sublime-snippet
+++ b/form/bs3-input-label.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<label for="input${1/(\w+)/\u\1/g}" ${2:class="col-sm-2"}>${3}</label>
+<label for="${1:input-id}" ${2:class="col-sm-2"}>${3}</label>
 ]]></content>
-	<tabTrigger>bs3-imput:label</tabTrigger>
+	<tabTrigger>bs3-input:label</tabTrigger>
 </snippet>


### PR DESCRIPTION
Same as 8fba0aae8959890e60b8579b34f3f935615e1050
Also a little typo in the `<tabTrigger>`
