### PR TITLE
Meta

### DIFF
--- a/template/bs3-html5-template.sublime-snippet
+++ b/template/bs3-html5-template.sublime-snippet
@@ -5,8 +5,7 @@
 	<head>
 		<title>${2:Title Page}</title>
 		<meta charset="UTF-8">
-		<meta name=description content="">
-		<meta name=viewport content="width=device-width, initial-scale=1">
+		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<!-- Bootstrap CSS -->
 		<link href="${3://netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css}" rel="stylesheet" media="screen">


### PR DESCRIPTION
meta(description) n'avait pas de cotte et meta(viewport) est écrite deux fois.
