### PR TITLE
replaced cdn urls from netdna to maxcdn

### DIFF
--- a/cdn/bs3-cdn-css.sublime-snippet
+++ b/cdn/bs3-cdn-css.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/css/bootstrap.min.css">
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/${1:3.3.4}/css/bootstrap.min.css">
 ]]></content>
 	<tabTrigger>bs3-cdn:css</tabTrigger>
 </snippet>

--- a/cdn/bs3-cdn-js.sublime-snippet
+++ b/cdn/bs3-cdn-js.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 <!-- Latest compiled and minified JS -->
 ${1:<script src="//code.jquery.com/jquery.js"></script>}
-<script src="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/js/bootstrap.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/${1:3.3.4}/js/bootstrap.min.js"></script>
 ]]></content>
 	<tabTrigger>bs3-cdn:js</tabTrigger>
 </snippet>

--- a/cdn/bs3-cdn.sublime-snippet
+++ b/cdn/bs3-cdn.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
 	<content><![CDATA[
 <!-- Latest compiled and minified CSS & JS -->
-<link rel="stylesheet" media="screen" href="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/css/bootstrap.min.css">
+<link rel="stylesheet" media="screen" href="//maxcdn.bootstrapcdn.com/bootstrap/${1:3.3.4}/css/bootstrap.min.css">
 ${2:<script src="//code.jquery.com/jquery.js"></script>}
-<script src="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/js/bootstrap.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/${1:3.3.4}/js/bootstrap.min.js"></script>
 ]]></content>
 	<tabTrigger>bs3-cdn</tabTrigger>
 </snippet>


### PR DESCRIPTION
We are recommend all CDN urls use the `maxcdn.bootstrapcdn.com` hostname.  While `netdna` will still work, it is considered legacy. Thanks!