### PR TITLE
Added https to jquery cdn reference to correct broken link in bs3-cdn

### DIFF
--- a/cdn/bs3-cdn.sublime-snippet
+++ b/cdn/bs3-cdn.sublime-snippet
@@ -2,7 +2,7 @@
 	<content><![CDATA[
 <!-- Latest compiled and minified CSS & JS -->
 <link rel="stylesheet" media="screen" href="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/css/bootstrap.min.css">
-${2:<script src="//code.jquery.com/jquery.js"></script>}
+${2:<script src="https://code.jquery.com/jquery.js"></script>}
 <script src="//netdna.bootstrapcdn.com/bootstrap/${1:3.3.4}/js/bootstrap.min.js"></script>
 ]]></content>
 	<tabTrigger>bs3-cdn</tabTrigger>


### PR DESCRIPTION
Currently the bs3-cdn won't work as is, because of a broken jQuery link. Currently, the link for jQuery simply shows up as: //code.jquery.com/jquery.js .

 This will trigger the following errors:
GET file://code.jquery.com/jquery.js net::ERR_FILE_NOT_FOUND
bootstrap.min.js:6 Uncaught Error: Bootstrap's JavaScript requires jQuery(anonymous function) @ bootstrap.min.js:6

Uncaught Error: Bootstrap's JavaScript requires jQuery

...

In order to fix this error, the url should be **https:**//code.jquery.com/jquery.js