### PR TITLE
Amended docs to address leading '<' character

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ There are 3 methods for installing this plugin.
 
 ### Usage
 
-Start typing `<bs3` in html files and the autocomplete window opens. It matches fuzzily. So you can type `<bs3radio` to find the `bs3-input:radio` snippet.
+Start typing `bs3` in html files and the autocomplete window opens. It matches fuzzily. So you can type `bs3radio` to find the `bs3-input:radio` snippet.
 
-Be sure you have enabled "<" and "bs" in your Preferences.sublime-settings:
+Be sure you have enabled "bs" in your Preferences.sublime-settings:
 
-`"auto_complete_triggers": [{"selector": "text.html", "characters": "<"},{"selector": "text.html", "characters": "bs3"}]`
+`"auto_complete_triggers": [{"selector": "text.html", "characters": "bs3"}]`
 
 ### CDN
 


### PR DESCRIPTION
Addresses Issue #99:

Docs incorrectly state "start typing '<bs3' " instead of just "bs3".

Don't use the "<" tag when typing, just start typing with "bs...". After confirmation (i.e when u hit ENTER or TAB key depending on ur editor), there should be no extra leading "<" character. 

Problem is "<tabTrigger>" in code snippets do not include leading "<" but starts from "bs...". So e.g if u type "<bs3-col" the plugin will decode only "bs3-col" leaving the "<" character behind
