### PR TITLE
add support for both, container and container-fluid

### DIFF
--- a/grid/bs3-container-fluid.sublime-snippet
+++ b/grid/bs3-container-fluid.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<content><![CDATA[
+<div class="container-fluid">
+	${0}
+</div>
+]]></content>
+	<tabTrigger>bs3-container-fluid</tabTrigger>
+</snippet>

--- a/grid/bs3-container.sublime-snippet
+++ b/grid/bs3-container.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<div class="container-fluid">
+<div class="container">
 	${0}
 </div>
 ]]></content>


### PR DESCRIPTION
I think both, `.container` and `.container-fluid` should be supported. The old implementation was a bit confusing.